### PR TITLE
Migrate SmartShare library to @idpass/smartshare-react-native

### DIFF
--- a/machines/request.ts
+++ b/machines/request.ts
@@ -1,4 +1,4 @@
-import SmartShare from 'react-native-idpass-smartshare';
+import SmartShare from '@idpass/smartshare-react-native';
 import BluetoothStateManager from 'react-native-bluetooth-state-manager';
 import { EmitterSubscription } from 'react-native';
 import { EventFrom, send, sendParent, StateFrom } from 'xstate';

--- a/machines/scan.ts
+++ b/machines/scan.ts
@@ -1,4 +1,4 @@
-import SmartShare, { ConnectionParams } from 'react-native-idpass-smartshare';
+import SmartShare from '@idpass/smartshare-react-native';
 import LocationEnabler from 'react-native-location-enabler';
 import { EventFrom, send, sendParent, StateFrom } from 'xstate';
 import { createModel } from 'xstate/lib/model';
@@ -386,7 +386,7 @@ export const scanMachine = model.createMachine(
 
     guards: {
       isQrValid: (_, event: ScanEvent) => {
-        const param: ConnectionParams = Object.create(null);
+        const param: SmartShare.ConnectionParams = Object.create(null);
         try {
           Object.assign(param, JSON.parse(event.params));
           return 'cid' in param && 'pk' in param;

--- a/machines/smartshare.ts
+++ b/machines/smartshare.ts
@@ -1,4 +1,4 @@
-import SmartShare, { ConnectionParams } from 'react-native-idpass-smartshare';
+import SmartShare from '@idpass/smartshare-react-native';
 import { EmitterSubscription } from 'react-native';
 import { createModel } from 'xstate/lib/model';
 import { Message } from '../shared/Message';
@@ -128,7 +128,7 @@ export const smartShareMachine = model.createMachine(
 
     guards: {
       isQrValid: (context, event: DeviceFoundEvent) => {
-        const params: ConnectionParams = Object.create(null);
+        const params: SmartShare.ConnectionParams = Object.create(null);
         try {
           Object.assign(params, JSON.parse(event.qrCode));
           return 'cid' in params && 'pk' in params;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/poppins": "^0.2.0",
+        "@idpass/smartshare-react-native": "^0.2.0",
         "@react-native-async-storage/async-storage": "~1.15.0",
         "@react-native-community/netinfo": "6.0.2",
         "@react-navigation/bottom-tabs": "^6.0.7",
@@ -34,7 +35,6 @@
         "react-native-device-info": "^8.4.8",
         "react-native-elements": "^3.4.2",
         "react-native-gesture-handler": "~1.10.2",
-        "react-native-idpass-smartshare": "^0.1.0",
         "react-native-keychain": "^8.0.0",
         "react-native-location-enabler": "^4.1.0",
         "react-native-qrcode-svg": "^6.1.1",
@@ -3952,6 +3952,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
       "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g=="
+    },
+    "node_modules/@idpass/smartshare-react-native": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@idpass/smartshare-react-native/-/smartshare-react-native-0.2.0.tgz",
+      "integrity": "sha512-/bjkg1u3msFLGqxl3hVTCjDm6hJRi0yuk+rEzQLjkn249VioLHJ7SBbvPzH5jUC2pW6JIK7UtAaevS5VoMgicw==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@jest/create-cache-key-function": {
       "version": "26.6.2",
@@ -21188,15 +21197,6 @@
         "ua-parser-js": "^0.7.30"
       }
     },
-    "node_modules/react-native-idpass-smartshare": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-idpass-smartshare/-/react-native-idpass-smartshare-0.1.0.tgz",
-      "integrity": "sha512-oYgvNHZK0wJl8ITzYttnhKfLfGlZq3jjFVSLtd+lOduGA6GvLxjU/BR43CVZuPZ2nGSm4+4NeTtKQzpAzrtyGw==",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-keychain": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-8.0.0.tgz",
@@ -30759,6 +30759,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
       "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g=="
+    },
+    "@idpass/smartshare-react-native": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@idpass/smartshare-react-native/-/smartshare-react-native-0.2.0.tgz",
+      "integrity": "sha512-/bjkg1u3msFLGqxl3hVTCjDm6hJRi0yuk+rEzQLjkn249VioLHJ7SBbvPzH5jUC2pW6JIK7UtAaevS5VoMgicw==",
+      "requires": {}
     },
     "@jest/create-cache-key-function": {
       "version": "26.6.2",
@@ -44865,12 +44871,6 @@
           }
         }
       }
-    },
-    "react-native-idpass-smartshare": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-idpass-smartshare/-/react-native-idpass-smartshare-0.1.0.tgz",
-      "integrity": "sha512-oYgvNHZK0wJl8ITzYttnhKfLfGlZq3jjFVSLtd+lOduGA6GvLxjU/BR43CVZuPZ2nGSm4+4NeTtKQzpAzrtyGw==",
-      "requires": {}
     },
     "react-native-keychain": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/poppins": "^0.2.0",
+    "@idpass/smartshare-react-native": "^0.2.0",
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/netinfo": "6.0.2",
     "@react-navigation/bottom-tabs": "^6.0.7",
@@ -33,7 +34,6 @@
     "react-native": "0.64.3",
     "react-native-app-intro-slider": "^4.0.4",
     "react-native-bluetooth-state-manager": "^1.3.2",
-    "react-native-idpass-smartshare": "^0.1.0",
     "react-native-device-info": "^8.4.8",
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "~1.10.2",

--- a/types/idpass__smartshare-react-native/index.d.ts
+++ b/types/idpass__smartshare-react-native/index.d.ts
@@ -1,7 +1,7 @@
 import { EmitterSubscription } from 'react-native';
 import { BluetoothState } from 'react-native-bluetooth-state-manager';
 
-declare module 'react-native-idpass-smartshare' {
+declare module '@idpass/smartshare-react-native' {
   class BluetoothApi {
     getConnectionParameters: () => string;
 


### PR DESCRIPTION
Resolves #41 

### Changes

- Replace `react-native-idpass-smartshare` library with `@idpass/smartshare-react-native`
- Edit imports in code to import from `@idpass/smartshare-react-native`