### PR TITLE
Adding SonarQube settings file to exclude relevant files for React Native

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.exclusions=.github/**, .vscode/**, android/**, assets/**, build/**, ios/**, node_modules/**, scripts/**
+


### PR DESCRIPTION
These settings avoids false positives and ensures only files generated by us are scanned.