### PR TITLE
Inline credits markdown content

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,10 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: [
+      ['babel-plugin-inline-import', {
+        extensions: ['.md']
+      }]
+    ]
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@babel/core": "^7.12.9",
         "@types/react": "~17.0.21",
         "@types/react-native": "~0.64.12",
+        "babel-plugin-inline-import": "^3.0.0",
         "eas-cli": "^0.37.0",
         "expo-cli": "^4.13.0",
         "sharp": "^0.29.3",
@@ -6316,6 +6317,15 @@
       "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dependencies": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "node_modules/babel-plugin-inline-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-import/-/babel-plugin-inline-import-3.0.0.tgz",
+      "integrity": "sha512-thnykl4FMb8QjMjVCuZoUmAM7r2mnTn5qJwrryCvDv6rugbJlTHZMctdjDtEgD0WBAXJOLJSGXN3loooEwx7UQ==",
+      "dev": true,
+      "dependencies": {
+        "require-resolve": "0.0.2"
       }
     },
     "node_modules/babel-plugin-module-resolver": {
@@ -19101,6 +19111,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/path-extra": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/path-extra/-/path-extra-1.0.3.tgz",
+      "integrity": "sha1-fBEhiablDVlXkOetIDfkTkEMEWY=",
+      "dev": true
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -22241,6 +22257,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/require-resolve": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
+      "integrity": "sha1-urQQqxruLz9Vt5MXRR3TQodk5vM=",
+      "dev": true,
+      "dependencies": {
+        "x-path": "^0.0.2"
+      }
     },
     "node_modules/requireg": {
       "version": "0.2.2",
@@ -27233,6 +27258,15 @@
       "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
       "dependencies": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/x-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x-path/-/x-path-0.0.2.tgz",
+      "integrity": "sha1-KU0Ha7l6dwbMBwu7Km/YxU32exI=",
+      "dev": true,
+      "dependencies": {
+        "path-extra": "^1.0.2"
       }
     },
     "node_modules/xcode": {
@@ -32696,6 +32730,15 @@
       "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-inline-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-import/-/babel-plugin-inline-import-3.0.0.tgz",
+      "integrity": "sha512-thnykl4FMb8QjMjVCuZoUmAM7r2mnTn5qJwrryCvDv6rugbJlTHZMctdjDtEgD0WBAXJOLJSGXN3loooEwx7UQ==",
+      "dev": true,
+      "requires": {
+        "require-resolve": "0.0.2"
       }
     },
     "babel-plugin-module-resolver": {
@@ -42942,6 +42985,12 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
+    "path-extra": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/path-extra/-/path-extra-1.0.3.tgz",
+      "integrity": "sha1-fBEhiablDVlXkOetIDfkTkEMEWY=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -45464,6 +45513,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "require-resolve": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
+      "integrity": "sha1-urQQqxruLz9Vt5MXRR3TQodk5vM=",
+      "dev": true,
+      "requires": {
+        "x-path": "^0.0.2"
+      }
     },
     "requireg": {
       "version": "0.2.2",
@@ -49512,6 +49570,15 @@
       "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
       "requires": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "x-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x-path/-/x-path-0.0.2.tgz",
+      "integrity": "sha1-KU0Ha7l6dwbMBwu7Km/YxU32exI=",
+      "dev": true,
+      "requires": {
+        "path-extra": "^1.0.2"
       }
     },
     "xcode": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/core": "^7.12.9",
     "@types/react": "~17.0.21",
     "@types/react-native": "~0.64.12",
+    "babel-plugin-inline-import": "^3.0.0",
     "eas-cli": "^0.37.0",
     "expo-cli": "^4.13.0",
     "sharp": "^0.29.3",

--- a/screens/Profile/Credits.tsx
+++ b/screens/Profile/Credits.tsx
@@ -1,15 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Asset } from 'expo-asset';
 import { Dimensions, Image, StyleSheet, View } from 'react-native';
 import { Divider, Icon, ListItem, Overlay } from 'react-native-elements';
 import Markdown from 'react-native-simple-markdown'
 import { Button, Text, Column, Row } from '../../components/ui';
 import { Colors } from '../../components/ui/styleUtils';
-const mdFile = require('../../Credits.md')
+import creditsContent from '../../Credits.md';
 
 export const Credits: React.FC<CreditsProps> = (props) => {
   const [isViewing, setIsViewing] = useState(false);
-  const [content, setContent] = useState("");
   const images = {
     'docs/images/newlogic_logo.png' : require('../../docs/images/newlogic_logo.png'),
     'docs/images/id_pass_logo.png' : require('../../docs/images/id_pass_logo.png'),
@@ -39,13 +38,6 @@ export const Credits: React.FC<CreditsProps> = (props) => {
     }
   }
 
-  const fetchLocalFile = async () => {
-    let file = Asset.fromModule(mdFile)
-    file = await fetch(file.uri)
-    file = await file.text()
-    setContent(file);
-  }
-
   const rules = {
     image: {
       react: (node, output, state) => (
@@ -59,12 +51,6 @@ export const Credits: React.FC<CreditsProps> = (props) => {
       ),
     }
   }
-
-  useEffect(() => {
-    (async () => {
-      await fetchLocalFile();
-    })();
-  }, [])
 
   return (
     <ListItem bottomDivider onPress={() => setIsViewing(true)}>
@@ -88,7 +74,7 @@ export const Credits: React.FC<CreditsProps> = (props) => {
           <View style={styles.markdownView}>
             <Markdown
               rules={rules}
-              children={content}
+              children={creditsContent}
               styles={markdownStyles}/>
           </View>
         </View>


### PR DESCRIPTION
### Changes

- Use `babel-plugin-inline-import` to inline the contents of the credits markdown file and use it directly instead of having to fetch it during runtime