### PR TITLE
Fix biometric prompt translation error

### DIFF
--- a/machines/biometrics.ts
+++ b/machines/biometrics.ts
@@ -1,7 +1,6 @@
 import { createModel } from 'xstate/lib/model';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { EventFrom, MetaObject, StateFrom } from 'xstate';
-import i18next from '../i18n';
 
 // ----- CREATE MODEL ---------------------------------------------------------
 const model = createModel(
@@ -15,7 +14,7 @@ const model = createModel(
   {
     events: {
       SET_IS_AVAILABLE: (data: boolean) => ({ data }),
-      SET_AUTH: (data: any[]) => ({ data }),
+      SET_AUTH: (data: unknown[]) => ({ data }),
       SET_IS_ENROLLED: (data: boolean) => ({ data }),
       SET_STATUS: (data: boolean) => ({ data }),
 
@@ -152,12 +151,12 @@ export const biometricsMachine = model.createMachine(
         states: {
           unavailable: {
             meta: {
-              message: i18next.t('AuthScreen.errors.unavailable'),
+              message: 'errors.unavailable',
             },
           },
           unenrolled: {
             meta: {
-              message: i18next.t('AuthScreen.errors.unenrolled'),
+              message: 'errors.unenrolled',
             },
             on: {
               RETRY_AUTHENTICATE: {
@@ -176,12 +175,12 @@ export const biometricsMachine = model.createMachine(
               1000: '#biometrics.available',
             },
             meta: {
-              message: i18next.t('AuthScreen.errors.failed'),
+              message: 'errors.failed',
             },
           },
           error: {
             meta: {
-              message: i18next.t('AuthScreen.errors.generic'),
+              message: 'errors.generic',
             },
           },
         },

--- a/screens/AuthScreenController.ts
+++ b/screens/AuthScreenController.ts
@@ -16,6 +16,7 @@ import {
   selectUnenrolledNotice,
 } from '../machines/biometrics';
 import { SettingsEvents } from '../machines/settings';
+import { useTranslation } from 'react-i18next';
 
 export function useAuthScreen(props: RootRouteProps) {
   const { appService } = useContext(GlobalContext);
@@ -39,6 +40,8 @@ export function useAuthScreen(props: RootRouteProps) {
     props.navigation.navigate('Passcode', { setup: isSettingUp });
   };
 
+  const { t } = useTranslation('AuthScreen');
+
   useEffect(() => {
     if (isAuthorized) {
       props.navigation.reset({
@@ -58,11 +61,11 @@ export function useAuthScreen(props: RootRouteProps) {
       // handle biometric failure unknown error
     } else if (errorMsgBio) {
       // show alert message whenever biometric state gets failure
-      setHasAlertMsg(errorMsgBio);
+      setHasAlertMsg(t(errorMsgBio));
 
       // handle any unenrolled notice
     } else if (unEnrolledNoticeBio) {
-      setHasAlertMsg(unEnrolledNoticeBio);
+      setHasAlertMsg(t(unEnrolledNoticeBio));
 
       // we dont need to see this page to user once biometric is unavailable on its device
     } else if (isUnavailableBio) {

--- a/screens/Profile/ProfileScreenController.ts
+++ b/screens/Profile/ProfileScreenController.ts
@@ -21,6 +21,7 @@ import {
 } from '../../machines/biometrics';
 import { MainRouteProps } from '../../routes/main';
 import { GlobalContext } from '../../shared/GlobalContext';
+import { useTranslation } from 'react-i18next';
 
 export function useProfileScreen({ navigation }: MainRouteProps) {
   const { appService } = useContext(GlobalContext);
@@ -38,6 +39,7 @@ export function useProfileScreen({ navigation }: MainRouteProps) {
     bioService,
     selectUnenrolledNotice
   );
+  const { t } = useTranslation('AuthScreen');
 
   useEffect(() => {
     setTimeout(async () => {
@@ -57,7 +59,7 @@ export function useProfileScreen({ navigation }: MainRouteProps) {
     } else {
       const error: string = errorMsgBio ?? unEnrolledNoticeBio ?? '';
       if (error != '') {
-        setHasAlertMsg(error);
+        setHasAlertMsg(t(error));
       }
     }
   }, [isSuccessBio, errorMsgBio, unEnrolledNoticeBio]);


### PR DESCRIPTION
To replicate the issue :
 - Remove fingerprint enrollment on your device
 - Clear the app and go back to onboarding
 - Tab on Use biometric (an error should prompt)
 
(Test in profile)
 - Go to profile screen
 - switch on the biometrics (an error should prompt)
 
 Issue will prompt "AuthScreen.errors.unenrolled"
 Fixed should prompt  "To use Biometrics, please enroll your fingerprint in your device settings"
 