### PR TITLE
Moving over GitHub workflow and issue template from develop to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug, triage
 assignees: jeremi, kneckinator
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -23,16 +23,15 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Inji app version: [e.g 0.3.0]
+- Mimoto version: [e.g 1.2.x]
+- MOSIP Version: [e.g. 1.2.1]
+- Mimoto server: [e.g. https://.....com]
+- MOSIP server: [e.g. https://...mosip.com]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/android-custom-build.yml
+++ b/.github/workflows/android-custom-build.yml
@@ -1,7 +1,7 @@
 name: ID PASS - MOSIP Resident Application Custom build
 
 env:
-  backendServiceDefaultUrl: https://dev2.mosip.net/residentmobileapp
+  backendServiceDefaultUrl: https://api-internal.qa4.mosip.net/residentmobileapp
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
       backendServiceUrl:
         description: 'Backend service URL'
         required: true
-        default: 'https://dev2.mosip.net/residentmobileapp'
+        default: 'https://api-internal.qa4.mosip.net/residentmobileapp'
         type: string
 
 jobs:


### PR DESCRIPTION
Moving over GitHub workflow and issue template from `develop` to `main` to facilitate switch of GitHub default branch