### PR TITLE
#259 #260 Error message should be revised when biometrics is not enrolled in device settings page but still resident use biometric unlock

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -54,7 +54,7 @@
     "usePasscode": "I'd rather use a passcode",
     "errors": {
       "unavailable": "Device does not support Biometrics",
-      "unenrolled": "To use Biometrics, please enroll your fingerprint in your device settings",
+      "unenrolled": "To use Biometrics, please enroll your biometrics in your device settings",
       "failed": "Failed to authenticate with Biometrics",
       "generic": "There seems to be an error in Biometrics authentication"
     }

--- a/locales/fil.json
+++ b/locales/fil.json
@@ -54,7 +54,7 @@
     "usePasscode": "Gumamit na lang ng passcode",
     "errors": {
       "unavailable": "Hindi sinusuportahan ng device ang Biometrics",
-      "unenrolled": "Upang magamit ang Biometrics, mangyaring i-enroll ang iyong fingerprint sa mga setting ng iyong device",
+      "unenrolled": "Upang magamit ang Biometrics, mangyaring i-enroll ang iyong biometrics sa mga setting ng iyong device",
       "failed": "Nabigong mag-authenticate gamit ang Biometrics",
       "generic": "May problema sa Biometrics authentication"
     }

--- a/screens/AuthScreen.strings.json
+++ b/screens/AuthScreen.strings.json
@@ -4,7 +4,7 @@
   "usePasscode": "I'd rather use a passcode",
   "errors": {
     "unavailable": "Device does not support Biometrics",
-    "unenrolled": "To use Biometrics, please enroll your fingerprint in your device settings",
+    "unenrolled": "To use Biometrics, please enroll your biometrics in your device settings",
     "failed": "Failed to authenticate with Biometrics",
     "generic": "There seems to be an error in Biometrics authentication"
   }


### PR DESCRIPTION
https://github.com/mosip/inji/issues/259
https://github.com/mosip/inji/issues/260