### PR TITLE
#351 #373 Able to get inside app without adding passcode

### DIFF
--- a/machines/auth.ts
+++ b/machines/auth.ts
@@ -162,7 +162,7 @@ export const authMachine = model.createMachine(
         return context.passcode !== '';
       },
       hasBiometricSet: (context) => {
-        return context.biometrics !== '';
+        return context.biometrics !== '' && context.passcode !== '';
       },
     },
   }

--- a/machines/settings.typegen.ts
+++ b/machines/settings.typegen.ts
@@ -8,9 +8,9 @@ export interface Typegen0 {
   'invokeSrcNameMap': {};
   'missingImplementations': {
     actions: never;
-    services: never;
-    guards: never;
     delays: never;
+    guards: never;
+    services: never;
   };
   'eventsCausingActions': {
     requestStoredContext: 'xstate.init';
@@ -24,11 +24,11 @@ export interface Typegen0 {
     updateName: 'UPDATE_NAME';
     updateVcLabel: 'UPDATE_VC_LABEL';
   };
-  'eventsCausingServices': {};
+  'eventsCausingDelays': {};
   'eventsCausingGuards': {
     hasData: 'STORE_RESPONSE';
   };
-  'eventsCausingDelays': {};
+  'eventsCausingServices': {};
   'matchesStates': 'idle' | 'init' | 'storingDefaults';
   'tags': never;
 }


### PR DESCRIPTION
iOS - Able to unlock the inji app just with biometrics without passcode as a fallback. #373
Android - Able to get inside app without adding pin #351